### PR TITLE
Fixes #18 PKSimCreatePopulation: Ontogeny factor for enzymes not set

### DIFF
--- a/code/MoBiSettings.m
+++ b/code/MoBiSettings.m
@@ -4,12 +4,11 @@
 %   MOBISETTINGS  the default paths are used
 %
 %   MOBISETTINGS(simModelSchemaPath, simModelCompConfigPath, eventsAssemblyPath)
-%       simModelSchemaPath (string, optional): path to SimModel xml schema.
-%       simModelCompConfigPath (string, optional): full file name of SimModelComp configuration file
+%       simModelSchemaPath (string, optional): path to SimModel xml schema (OSPSuite.SimModel.xsd).
+%       simModelCompConfigPath (string, optional): path to SimModelComp configuration file (OSPSuite_SimModelComp.xml)
 %       eventsAssemblyPath (string, optional):     path to .NET assembly intended for providing "events" if called from .NET application
 
 % Open Systems Pharmacology Suite;  http://open-systems-pharmacology.org  
-% Date: 20-May-2011
 
 % SimModel Schema
 global MOBI_SETTINGS;

--- a/code/auxiliaries/OSPSuiteVersionInfo.m
+++ b/code/auxiliaries/OSPSuiteVersionInfo.m
@@ -1,6 +1,6 @@
 function T = OSPSuiteVersionInfo
 
-T.OSPSuiteVersion = 7.3;
+T.OSPSuiteVersion = 7.4;
 T.SimModelVersion = 3.0;
 T.SimModelVersion_Linux = 2.2;
 T.SimModelCompName='OSPSuite_SimModelComp.xml';

--- a/code/auxiliaries/checkInputSimulationIndex.m
+++ b/code/auxiliaries/checkInputSimulationIndex.m
@@ -6,7 +6,6 @@ function checkInputSimulationIndex(simulationIndex)
 %       simulationIndex index of the simulation (see also INITSIMULATION option 'addFile')  
 
 % Open Systems Pharmacology Suite;  http://open-systems-pharmacology.org
-% Date: 20-Sep-2010
 
 global DCI_INFO;
 
@@ -21,7 +20,7 @@ elseif simulationIndex==0
     end
 elseif isempty(DCI_INFO)
         error('MoBiToolbox:Basis:SimulationIndex',...
-            'SimulationIndex %d is not valid. There is none simulation initialized.',...
+            'SimulationIndex %d is not valid. There is no simulation initialized.',...
             simulationIndex);
 elseif length(DCI_INFO)<simulationIndex    
         error('MoBiToolbox:Basis:SimulationIndex',...

--- a/code/auxiliaries/loadPKSimMatlabDLL.m
+++ b/code/auxiliaries/loadPKSimMatlabDLL.m
@@ -11,6 +11,7 @@ function isCanceled = loadPKSimMatlabDLL
     if isempty(which('PKSim.Matlab.MoleculeOntogeny'))
         NET.addAssembly([pathToPKSimInstallDir '\PKSim.Matlab.dll']);
         NET.addAssembly('System.Core');
+        %NET.addAssembly([pathToPKSimInstallDir '\Microsoft.Extensions.Logging.Abstractions.dll']);
         NET.addAssembly([pathToPKSimInstallDir '\PKSim.Core.dll']);
     end
     

--- a/code/processSimulation.m
+++ b/code/processSimulation.m
@@ -21,8 +21,9 @@ function success=processSimulation(simulationIndex)
 % success=processSimulation('*');
 %
 % see also INITSIMULATION
+
 % Open Systems Pharmacology Suite;  http://open-systems-pharmacology.org
-% Date: 24-Sep-2010
+
 
 global DCI_INFO;
 global MOBI_SETTINGS;


### PR DESCRIPTION
Fixes #14 Increment version 7.3=>7.4
Fixes #17 MoBiSettings help text
Fixes #19 "help processSimulation": text shows obsolete Matlab links
Fixes #20 Rephrase error: "There is none simulation initialized"